### PR TITLE
Do not color anything bright red

### DIFF
--- a/pywikibugs.py
+++ b/pywikibugs.py
@@ -69,9 +69,9 @@ def build_message(parsed_email, hide_product=False):
     text = ""
     
     if not hide_product:
-        text += colorify(parsed_email["X-Bugzilla-Product"], "red")
+        text += colorify(parsed_email["X-Bugzilla-Product"], "green")
     if parsed_email["X-Bugzilla-Component"] != "General":
-        text += " " + colorify(parsed_email["X-Bugzilla-Component"], "green")
+        text += " / " + colorify(parsed_email["X-Bugzilla-Component"], "green")
     text += ": "
     text += parsed_email["summary"] + " - "
     


### PR DESCRIPTION
Use green instead of red for product name. Separate product
from component with a slash instead of by color.
