### PR TITLE
Reduce gerritadmin traffic a bit by ignoring it's status changes

### DIFF
--- a/pywikibugs.py
+++ b/pywikibugs.py
@@ -66,7 +66,7 @@ channels = {"#wikimedia-dev": (lambda x: True, {}),
 def send_messages(bot, parsed_email):
     # first, build the message
     for channel, (filter, params) in channels.items():
-        if filter(parsed_email):
+        if filter(parsed_email) and not (parsed_email["email"] == "gerritadmin@wikimedia.org" and "changes" in parsed_email and "Status" in parsed_email["changes"]):
             msg = build_message(parsed_email, **params)
             bot.privmsg(channel, msg)
     


### PR DESCRIPTION
Unfortunately gerritadmin has to make its 'new patch' comment in a
separate API request to modifying the status, due to BZ API limitations.

I'd prefer that the notification bot was a little quieter about this, so this
patch suppresses the (IMO) less helpful of the two changes

(Untested)
