### PR TITLE
Suppress gerritadmin entirely

### DIFF
--- a/pywikibugs.py
+++ b/pywikibugs.py
@@ -63,15 +63,13 @@ channels = {"#wikimedia-dev": (lambda x: True, {}),
             "#wikimedia-mobile": (lambda x: x.get("X-Bugzilla-Product", None) in ["Wikimedia Mobile", "Commons App", "Wikipedia App", "MobileFrontend"], {}),
 }
 
-def is_gerrit_status_change(parsed_email):
-    return parsed_email["email"] == "gerritadmin@wikimedia.org" and \
-           "changes" in parsed_email and \
-           "Status" in parsed_email["changes"]
+def is_gerrit_change(parsed_email):
+    return parsed_email["email"] == "gerritadmin@wikimedia.org"
 
 def send_messages(bot, parsed_email):
     # first, build the message
     for channel, (filter, params) in channels.items():
-        if filter(parsed_email) and not is_gerrit_status_change(parsed_email):
+        if filter(parsed_email) and not is_gerrit_change(parsed_email):
             msg = build_message(parsed_email, **params)
             bot.privmsg(channel, msg)
     


### PR DESCRIPTION
Per issue #7, all the channels that this bot is in have grrrit-wm. It doesn't make much sense to forward anything from gerritadmin there.
