### PR TITLE
Instruct pep8/flake8 to ignore lines too long

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+; E501 line too long (X > 79 characters)
+ignore = E501
+
+[pep8]
+; E501 line too long (X > 79 characters)
+ignore = E501


### PR DESCRIPTION
There is a lot of overly long lines (more than 79 characters).  I am not
sure it is worth fixing them so just instruct flake8 and pep8 to ignore
them entirely (error E501).
