### PR TITLE
Introduce default and firehose channels

### DIFF
--- a/channels.py
+++ b/channels.py
@@ -6,8 +6,6 @@ channels = {
     "#wikimedia-corefeatures":
         lambda x: (x.get("X-Bugzilla-Product", None) == "MediaWiki extensions") and \
                   (x.get("X-Bugzilla-Component", None) in ["Echo", "Flow", "LiquidThreads", "PageCuration", "Thanks", "WikiLove"]),
-    "#wikimedia-dev":
-        lambda x: True,
     "#wikimedia-labs":
         lambda x: x.get("X-Bugzilla-Product", None) in ["Tool Labs tools", "Wikimedia Labs"],
     "#wikimedia-mobile":
@@ -15,8 +13,6 @@ channels = {
     "#wikimedia-qa":
         lambda x: (x.get("X-Bugzilla-Product", None) == "Wikimedia") and \
                   (x.get("X-Bugzilla-Component", None) in ["Continuous integration", "Quality Assurance"]),
-    "#mediawiki-feed":
-        lambda x: True,
     "#mediawiki-visualeditor":
         lambda x: x.get("X-Bugzilla-Product", None) in ["VisualEditor", "OOjs", "OOjs UI"] or \
                   (
@@ -26,3 +22,6 @@ channels = {
     "#mediawiki-parsoid":
         lambda x: x.get("X-Bugzilla-Product", None) in ["Parsoid"]
 }
+
+default_channel = "#wikimedia-dev"
+firehose_channel = "#mediawiki-feed"


### PR DESCRIPTION
Default channels get bugs that haven't been sent anywhere
else. Firehose channels get all bugs, no matter what.

In practice, this means that #wikimedia-dev will not get all the bugs
anymore. Bugs that are reported in other channels will not show up
in -dev. This should reduce bugnoise on -dev a fair bit, and also match
the behavior of grrrit-wm.
# mediawiki-feed will still get the unfiltered firehose of all bug changes.
